### PR TITLE
Create build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "faker-zig",
+    .version = "0.0.0",
+    .paths = .{"."},
+}


### PR DESCRIPTION
I am unable to install this package using `zig fetch --save git+https://github.com/cksac/faker-zig` and I get the following error...

```
error: unable to determine name; fetched package has no build.zig.zon file
```

This should fix the issue or at least be a step towards fixing the issue

In the `build.zig.zon` file I set the version to `0.0.0` since I cannot find a version number on this package in the Github repo.